### PR TITLE
Made nanosuit not useless

### DIFF
--- a/src/main/java/ml/pkom/advancedreborn/items/NanoSuitItem.java
+++ b/src/main/java/ml/pkom/advancedreborn/items/NanoSuitItem.java
@@ -94,7 +94,7 @@ public class NanoSuitItem extends TRArmourItem implements ArmorBlockEntityTicker
         ArrayListMultimap<EntityAttribute, EntityAttributeModifier> attributes = ArrayListMultimap.create(super.getAttributeModifiers(stack, slot));
 
         if (equipmentSlot == this.slot && getStoredEnergy(stack) > 0) {
-            attributes.put(EntityAttributes.GENERIC_ARMOR, new EntityAttributeModifier(MODIFIERS[slot.getEntitySlotId()], "Armor modifier", 2, EntityAttributeModifier.Operation.ADDITION));
+            attributes.put(EntityAttributes.GENERIC_ARMOR, new EntityAttributeModifier(MODIFIERS[slot.getEntitySlotId()], "Armor modifier", 6, EntityAttributeModifier.Operation.ADDITION));
         } else if (equipmentSlot == this.slot) {
             attributes.put(EntityAttributes.GENERIC_ARMOR, new EntityAttributeModifier(MODIFIERS[slot.getEntitySlotId()], "Armor modifier", -1, EntityAttributeModifier.Operation.ADDITION));
         }


### PR DESCRIPTION
2 armor per piece of armor is less than chain mail, there's basically no point in making it then. This armor set has a maximum capacity of 4M energy, costs a lot of effort and grinding to make, costs 8 diamonds to make and another 8 to even use it since you need an MFE to charge it, furthermore you need a lot of iron to even make the components for it. 

Having it give you less armor than chain mail makes it effectively useless.

6 armor per piece might seem like a lot but with the amount of time, effort and energy needed to make and maintain it I feel like it'd be much better this way.